### PR TITLE
Build: expand entities - helps with new libxml that became stricter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ po/%.po: release-notes.pot
     fi
 
 xml/release-notes.%.xml: po/%.po xml/release-notes.ent xml/release-notes.xml
-	xml2po -p $< -o $@ xml/release-notes.xml;
+	xml2po --expand-all-entities -p $< -o $@ xml/release-notes.xml;
 
 pdf: $(PDF_FILES)
 $(PDF_FILES): $(XML_FILES)


### PR DESCRIPTION
At least on some local tests, I could get this the release notes to build with this patch