### PR TITLE
Warning about no active firewall after install from live cd

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -206,6 +206,18 @@ systemctl start network.service</screen>
    </para>
   </section>
  </section>
+
+  <section>
+   <title>No firewall by default after installation from Live CD</title>
+   <para>
+    When installing from the Live CD no firewall will be active by
+    default.
+   </para>
+   <para>
+    Enable the firewall using YaST or with
+    <command>systemctl enable SuSEfirewall2; systemctl start SuSEfirewall2</command>
+   </para>
+  </section>
  <section id="general">
   <title>General</title>
   <para/>


### PR DESCRIPTION
Recreating the live images is not possible without much effort, so we should warn the users