### PR TITLE
Do not recode html files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,7 @@ $(SINGLE_HTML_FILES): $(XML_FILES)
 
 yast-html: | $(DIRS) $(YAST_HTML_FILES)
 $(YAST_HTML_FILES): xml/release-notes.ent xml/release-notes.xml
-	$(XSLTPROC_COMMAND) /usr/share/daps/daps-xslt/relnotes/yast.xsl xml/release-notes.xml > $@; \
-	recode latin1..ascii $@
+	$(XSLTPROC_COMMAND) /usr/share/daps/daps-xslt/relnotes/yast.xsl xml/release-notes.xml > $@
 
 txt: $(TXT_FILES)
 $(TXT_FILES): $(XML_FILES)


### PR DESCRIPTION
The output of xsltproc is already UTF8 files; the attempt to recode them
latin1..ascii would fail, as the input is not latin1.

This should actually address the build failure seen in Tumbleweed (and Leap 42.1)