### PR TITLE
Add note on hawk to hawk2 transition

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -180,6 +180,7 @@
       <listitem><para><literal>cadabra</literal>: the source code no longer builds.
        The successor <link xlink:href="http://cadabra.science/">version 2</link>
        is not stable yet.</para></listitem>
+      <listitem><para><literal>hawk</literal>: replaced by <literal>hawk2</literal></para></listitem>
     </itemizedlist>
   </section>
 


### PR DESCRIPTION
The `hawk` package is dropped from Leap 42.2 and replaced by the `hawk2` package.
