### PR TITLE
Add various KDE-related sections

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -220,6 +220,55 @@
      </listitem>
     </itemizedlist>
    </sect3>
+   <sect3 xml:id="sec.upgrade.422.synapticskde">
+    <title>Synaptics Touchpad Driver with KDE Plasma</title>
+    <para>
+      In &opensuseleap; 42.2 the X11 synaptics driver (package
+      <package>xf86-input-synaptics</package>) was not installed by default
+      (see <xref linkend="sec.upgrade.synaptics"/>), but KDE Plasma
+      only offers limited configuration options for the replacement, libinput.
+    </para>
+    <para>
+      Since &opensuseleap; 42.3 the <package>xf86-input-synaptics</package>
+      package is installed together with the KDE Plasma desktop (recommended
+      by <package>plasma5-workspace</package>).
+    </para>
+   </sect3>
+   <sect3 xml:id="sec.upgrade.422.baloofile">
+     <title>Changes in KDE Desktop Search Indexing</title>
+     <para>
+       In &opensuseleap; 42.3 the desktop search only indexes file names
+       by default, not the contents of files.
+     </para>
+     <para>
+       File content indexing needs to be reenabled manually, even if it was
+       enabled before, as the previous default was not saved to the
+       configuration. To do so, follow these steps:
+     </para>
+     <procedure>
+       <step>
+         <para>
+           Open the <guimenu>Desktop Configuration</guimenu> in the main menu
+           or krunner.
+         </para>
+       </step>
+       <step>
+         <para>
+           Click on <guimenu>Search</guimenu>.
+         </para>
+       </step>
+       <step>
+         <para>
+           Enable the checkbox <guimenu>Also index file content</guimenu>.
+         </para>
+       </step>
+       <step>
+         <para>
+           Click on <guimenu>Apply</guimenu>.
+         </para>
+       </step>
+       </procedure>
+   </sect3>
   </sect2>
 
   <sect2 xml:id="sec.upgrade.421">
@@ -512,45 +561,16 @@
    match any other category.
   </para>
 
-  <!-- Currently still exists in 42.3 (for the moment), so leaving this in.
-  - sknorr, 2017-02-17 -->
-
   <sect2 xml:id="sec.general.kdepim">
    <title>KDE Software for Personal Information Management (KDE PIM)</title>
    <para>
-    &thisversion; ships two versions of the KDE PIM (Kontact, KMail, etc.)
-    suite:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      The legacy 4.x version
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The version based on KDE Frameworks 5
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-    KDE PIM 4.x is no longer supported by upstream KDE, but was kept to avoid
-    disrupting user workflows.
+    KDE PIM 4.x is no longer supported by upstream KDE, but was kept in
+    &opensuseleap; 42.2 together with KDE PIM 5 to avoid disrupting user
+    workflows and allow for easier migration.
    </para>
    <para>
-    The two versions of KDE PIM are not co-installable. Some software, such
-    as KNode (package <package>knode</package>) require the legacy 4.x
-    version and will be uninstalled when installing any package from KDE PIM
-    5.x (for example, the package <package>kmail5</package>).
-   </para>
-   <para>
-    You are encouraged to switch to the newer 5.x version, as KDE PIM 4.x will
-    be removed in the future.
-   </para>
-   <para>
-    However, not all settings are migrated from the older version at this time.
-    For more information, see the bug report at
-    <link xlink:href="https://bugzilla.opensuse.org/show_bug.cgi?id=1001872"/>).
+    With &opensuseleap; 42.3 the KDE PIM 4.x stack got dropped and only the
+    current upstream-supported KDE PIM 5 stack is included.
    </para>
   </sect2>
 
@@ -611,6 +631,24 @@
      </para>
     </step>
    </procedure>
+  </sect2>
+
+  <sect2 xml:id="sec.general.plasmaglobalmenu">
+    <title>Global Menu Support in KDE Plasma</title>
+    <para>
+      With KDE Plasma 5.9, KDE reintroduced support for the global menu as
+      known from earlier KDE desktop releases.
+    </para>
+    <para>
+      In &opensuseleap; 42.3, the application menu bar plasmoid is
+      available as well.
+    </para>
+    <note xml:id="note.general.plasmaglobalmenu.otherapps">
+      <para>
+        Various applications not using the Qt toolkit may not support
+        the global menu at all or behave incorrectly.
+      </para>
+    </note>
   </sect2>
 
   <!-- <sect2 xml:id="sec.general.nonoss">


### PR DESCRIPTION
- X.org synaptics driver pulled in by default
- Global menu bar backport
- KDE PIM 4.x dropped
- Baloo only indexes file names by default