### PR TITLE
MP3 audio is supported in the default repo, but pkg might not be inst…

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -757,6 +757,18 @@
     </note>
   </sect2>
 
+  <sect2 xml:id="sec.general.mp3-media">
+    <title>Playing MP3 media files</title>
+    <para>
+      With the release of &opensuseleap; 42.3, the codecs to play MP3 media files
+      are now shipped as part of the standard repository.
+    </para>
+    <para>
+      Make sure to install the package <literal>gstreamer-plugins-ugly</literal>
+      to make use of this decoder in gstreamer based applications / frameworks.
+    </para>
+  </sect2>
+
   <sect2 xml:id="sec.general.libreoffice.type1">
    <title>No Support for Type-1 Fonts in LibreOffice</title>
    <para>


### PR DESCRIPTION
…alled

A default installation does not get the package installed (except GNOME installation,
which was traditionally GStreamer based and pulled the plugins in een before MP3 was there)