### PR TITLE
"remove &thisflovor;  because of written twice openSUSE Leap" (*)

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -432,7 +432,7 @@ setxkbmap <replaceable>[...]</replaceable> -option compose:<replaceable>COMPOSE_
    <title>Loading the Emacs <literal>psgml</literal> Module</title>
    <para>
     Because of conflicts with Emacs modules from the default installation,
-    &thisflavor; &thisversion; can no longer load the
+    &thisversion; can no longer load the
     <literal>psgml</literal> module automatically. For more information, see
     the file <filename>README</filename> from the package
     <package>psgml</package>.


### PR DESCRIPTION
I remove &thisflavor; because of "openSUSE Leap openSUSE Leap 15.0" in Release Notes.
&thisversion; is giving the correct outout "openSUSE Leap 15.0".