### PR TITLE
Change version number for Feature Wiki page

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -80,7 +80,7 @@
  </para>
  <para condition="pre;maintained">
   Major new features of &thisversion; are also listed at
-  <link xlink:href="https://en.opensuse.org/Features_15.0"/>.
+  <link xlink:href="https://en.opensuse.org/Features_15.1"/>.
  </para>
 
  <sect1 xml:id="installation">


### PR DESCRIPTION
Every Leap version has got a separate feature page in the Wiki. 15.1 will have an own one, too.
Therefore, I have changed the version number to 15.1 in the URL.