### PR TITLE
grammar error: neither nor

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -336,11 +336,11 @@
    <itemizedlist>
     <listitem>
      <para>
-      <package>libqt4</package>: Will not receive updates nor security fixes.
+      <package>libqt4</package>: Will neither receive updates nor security fixes.
       The package will be removed in the next version of &opensuseleap;.
      </para>
      <para>
-      <package>kdelibs4</package>: Will not receive updates nor security fixes.
+      <package>kdelibs4</package>: Will neither receive updates nor security fixes.
       The package will be removed in the next version of &opensuseleap;.
      </para>
     </listitem>


### PR DESCRIPTION
There is a grammar error. The German "weder-noch" is translated "neither-nor" instead of "not-nor".