### PR TITLE
Missing "and" between 2 packages

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -472,7 +472,7 @@
     </listitem>
     <listitem>
      <para>
-      <package>python-pyside</package>
+      <package>python-pyside</package> and
       <package>python-pyside-tools</package>: Removed because it depends on
       the insecure <command>libqt4</command>.
      </para>


### PR DESCRIPTION
python-pyside and python-pyside-tool are "both" removed. A "and" was missing for correct grammar.