### PR TITLE
Add note about gcompris (old gtk version) dropped

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -357,6 +357,14 @@
    <itemizedlist>
     <listitem>
      <para>
+      <package>gcompris</package> (old gtk version): Removed because it is 
+      unmaintained and has been replaced by now <package>gcompris-qt</package>.
+      See
+      <link xlink:href="https://www.gcompris.net"/>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       <package>artha</package>: Removed because it is unmaintained and has
       unpatched security issues. See
       <link xlink:href="https://bugzilla.opensuse.org/show_bug.cgi?id=1143860"/>.


### PR DESCRIPTION
* gcompris (old gtk version) dropped replaced by gcompris-qt package

To be in paar with the delete sr#814299 & the new submission sr#815300 & sr#815301