### PR TITLE
Fixed links to Docs: Startup Book

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -89,7 +89,7 @@
   <para>
    This section contains installation-related notes. For detailed upgrade
    instructions, see the documentation at
-   <link xlink:href="https://doc.opensuse.org/documentation/leap/startup/html/book.opensuse.startup/part-basics.html"/>.
+   <link xlink:href="https://doc.opensuse.org/documentation/leap/startup/html/book-startup/part-basics.html"/>.
   </para>
   <!-- <para>
    Make sure to also review <xref linkend="sec.driver"/>.
@@ -325,7 +325,7 @@
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="https://doc.opensuse.org/documentation/leap/startup/html/book.opensuse.startup/cha-update-osuse.html"/>
+     <link xlink:href="https://doc.opensuse.org/documentation/leap/startup/html/book-startup/cha-update-osuse.html"/>
     </para>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
There were wrong two links to Startup Book in Documentation.