### PR TITLE
Removal of digikam from ppc64le

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -368,6 +368,8 @@
      </para>
     </listitem>
     <listitem>
+     <package>digikam</package>: Digikam is no longer built for ppc64le and therefore will be provided only for x86_64, aarch64, and armv7 architectures.
+     </para>
      <para>
      <package>gap</package>: Removed because the package is not FHS-compliant.
       For more information, see <link xlink:href="https://bugzilla.opensuse.org/show_bug.cgi?id=1143860"/>.

--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -368,7 +368,7 @@
      </para>
     </listitem>
     <listitem>
-     <package>digikam</package>: Digikam is no longer built for ppc64le and therefore will be provided only for x86_64, aarch64, and armv7 architectures.
+     <package>digikam</package>: Digikam is no longer available on ppc64le as libqt5-qtwebkit was dropped. Package will be provided only for x86_64, aarch64, and armv7 architectures.
      </para>
      <para>
      <package>gap</package>: Removed because the package is not FHS-compliant.


### PR DESCRIPTION
Package is no longer built on ppc64le, therefore removing from media.