### PR TITLE
add nodejs-electron to removed packages list

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -368,6 +368,11 @@
      <para>
      <package>msgpack</package>: msgpack was replaced by msgpack-c and msgpack-cxx.
      </para>
+     <para>
+     <package>nodejs-electron</package>:
+      This old version of Electron is EOL, and we are unable to support this runtime throughout Leap's lifetime due to frequent ABI breaks.
+      Current versions of Electron are still available from the devel:languages:nodejs repository on OBS.
+     </para>
     </listitem>
    </itemizedlist>
 


### PR DESCRIPTION
see https://build.opensuse.org/request/show/1058844