### PR TITLE
Add note ibus is not started automatically by KDE Plasma (boo#1211977)

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -498,6 +498,17 @@ options nvidia NVreg_OpenRmEnableUnsupportedGpus=1
 
   </sect2>
 
+  </sect2>
+   <!-- boo#1211977 -->
+   <title>ibus can not start under KDE Plasma</title>
+   <para>
+     ibus can not start under KDE Plasma. This problem is fixed to add <literal>ibus-daemon -x</literal> to KDE Autostart.
+     How to add : Choose [System Settings] - [Setup and Shutdown] - [Autostart] - [Add...] - [Add Application...]
+     Then you can see application choosen dialog, Enter <literal>ibus-daemon -x<lliteral> to text box and click OK.
+     <link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=1211977" />.
+   </para>
+  </sect2>
+
   <!--
   <sect2 xml:id="desktop-ypbind">
    <!-/- boo#1129587 -/->


### PR DESCRIPTION
ibus is not started automatically by KDE Plasma (boo#1211977). So user who use ibus to input language such us Japanese can not input it.
I want to write it and workaround.
Thanks.