### PR TITLE
Correction of removed pkgs from bumlebee effort

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -390,17 +390,7 @@
      </listitem>
      <listitem>
        <para>
-         <package>dkms</package>
-       </para>
-     </listitem>
-     <listitem>
-       <para>
          <package>primus</package>
-       </para>
-     </listitem>
-     <listitem>
-       <para>
-         <package>VirtualGl</package>
        </para>
      </listitem>
    </itemizedlist>


### PR DESCRIPTION
Not all pkgs from the project were removed as dkms and VirtualGL are still used by other pkgs.