### PR TITLE
Remove KDE 4 paragraph

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -1008,12 +1008,6 @@
   <para>
    This section lists desktop issues and changes in &thisversion;.
   </para>
-  <sect2 xml:id="desktop-kde">
-   <title>KDE 4 and Qt 4 removal</title>
-   <para> KDE 4 packages will not be part of &opensuseleap; 15.4. Please update your system to
-    Plasma 5 and Qt 5. Some of Qt 4 packages might still remain for compatibility reasons. <link
-     xlink:href="https://bugzilla.opensuse.org/show_bug.cgi?id=1179613" />. </para>
-  </sect2>
 
   <sect2>
    <title><literal>nouveau</literal> disabled for Nvidia Turing and Ampere GPUs / openGPU


### PR DESCRIPTION
Reference to KDE 4 seems to me outdated, hence the PR to delete that paragraph.