### PR TITLE
Change minimum BTRFS size

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -129,7 +129,7 @@
     </listitem>
    </itemizedlist>
    <important>
-    <title><emphasis>Transactional Server</emphasis> Needs At Least 12 GB of Disk Space</title>
+    <title><emphasis>Transactional Server</emphasis> Needs At Least 16 GB of Disk Space</title>
     <para> The system role <emphasis>Transactional Server</emphasis> needs a disk size of at least
      12 GB to accommodate Btrfs snapshots. </para>
    </important>


### PR DESCRIPTION
Bring release notes more in line with https://documentation.suse.com/smart/systems-management/html/snapper-basic-concepts/index.html#snapper-default-settings.

see also #147 