### PR TITLE
Adjust link to doc.opensuse.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ When the above dependencies are satisfied, you can create output using:
 
 ### Web Version:
   * The web version is built in the [OBS Project Documentation:Auto](https://build.opensuse.org/project/show/Documentation:Auto).
-  * It is synced to the [documentation server](https://doc.opensuse.org/release-notes) using the scripts in the [doc.opensuse.org repository](https://github.com/openSUSE/doc-o-o).
+  * It is synced to the [documentation server](https://doc.opensuse.org/) using the scripts in the [doc.opensuse.org repository](https://github.com/openSUSE/doc-o-o).
 
 ## More Information
 


### PR DESCRIPTION
Adjust link to doc.opensuse.org as described in #149